### PR TITLE
Add autoWebview in caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npm run ionic-e2e:run:android
 npm run ionic-e2e:run:web
 ```
 
+> **NOTE:** Because this conference apps starts with a Webview the [Android](tests/config/wdio.android.config.ts) and [iOS](tests/config/wdio.ios.config.ts) 
+configs will automatically set the webview for you with this capability `appium:autoWebview`. This means you don't need to switch to the correct Webview yourself.
+
 ## Configuring WebdriverIO and Appium
 
 Edit `config/wdio.[platform].config.ts` based on the target platform to configure the settings and capabilities for the test.

--- a/tests/config/wdio.android.config.ts
+++ b/tests/config/wdio.android.config.ts
@@ -23,13 +23,17 @@ config.capabilities = [
     'appium:app': 'platforms/android/app/build/outputs/apk/debug/app-debug.apk',
     'appium:appWaitActivity': 'com.ionicframework.conferenceapp.MainActivity',
     'appium:newCommandTimeout': 240,
+    // This will automatically start the iOS app in a webview context,
+    // if your app starts in a native context then please put this to false and handle your own
+    // context switching
+    'appium:autoWebview': true,
     // Read the reset strategies very well, they differ per platform, see
     // http://appium.io/docs/en/writing-running-appium/other/reset-strategies/
     // When enabling the noReset the App will NOT be re-installed between sessions
     // This means that every test needs to maintain it's own state
     // `"appium:noReset":false` means that the app is removed and installed
     // between each test
-    // "appium:noReset": true,
+    'appium:noReset': true,
   },
 ];
 

--- a/tests/config/wdio.android.config.ts
+++ b/tests/config/wdio.android.config.ts
@@ -34,6 +34,10 @@ config.capabilities = [
     // `"appium:noReset":false` means that the app is removed and installed
     // between each test
     'appium:noReset': true,
+    // This will prevent appium to restart the app between the sessions,
+    // meaning between each spec file
+    // @ts-ignore
+    'appium:dontStopAppOnReset': true,
   },
 ];
 

--- a/tests/config/wdio.ios.config.ts
+++ b/tests/config/wdio.ios.config.ts
@@ -21,13 +21,18 @@ config.capabilities = [
     // The path to the app
     'appium:app': './platforms/ios/build/emulator/Ionic Conference App.app',
     'appium:newCommandTimeout': 240,
+    // This will automatically start the iOS app in a webview context,
+    // if your app starts in a native context then please put this to false and handle your own
+    // context switching
+    'appium:autoWebview': true,
     // Read the reset strategies very well, they differ per platform, see
     // http://appium.io/docs/en/writing-running-appium/other/reset-strategies/
     // When enabling the noReset the App will NOT be re-installed between sessions
     // This means that every test needs to maintain it's own state
     // `"appium:noReset":false` means that the app is removed and installed
     // between each test
-    // "appium:noReset": true,
+    'appium:noReset': true,
+    'appium:shouldTerminateApp': true,
   },
 ];
 config.maxInstances = 1;

--- a/tests/config/wdio.ios.config.ts
+++ b/tests/config/wdio.ios.config.ts
@@ -32,7 +32,6 @@ config.capabilities = [
     // `"appium:noReset":false` means that the app is removed and installed
     // between each test
     'appium:noReset': true,
-    'appium:shouldTerminateApp': true,
   },
 ];
 config.maxInstances = 1;

--- a/tests/config/wdio.shared.config.ts
+++ b/tests/config/wdio.shared.config.ts
@@ -1,9 +1,13 @@
+export interface SessionFlagsConfig extends WebdriverIO.Config {
+  firstAppStart: boolean;
+}
+
 /**
  * All not needed configurations, for this boilerplate, are removed.
  * If you want to know which configuration options you have then you can
  * check https://webdriver.io/docs/configurationfile
  */
-export const config: WebdriverIO.Config = {
+export const config: SessionFlagsConfig = {
   autoCompileOpts: {
     autoCompile: true,
     // see https://github.com/TypeStrong/ts-node#cli-and-programmatic-options
@@ -124,6 +128,18 @@ export const config: WebdriverIO.Config = {
      */
     timeout: 1200000,
   },
+
+  // =====
+  // Session flags
+  // =====
+  //
+  /**
+   * Custom property that is used to determine if the app is already launched for the first time
+   * This property is needed because the first time the app is automatically started, so a double
+   * restart is not needed.
+   */
+  firstAppStart: true,
+
   //
   // =====
   // Hooks

--- a/tests/config/wdio.shared.config.ts
+++ b/tests/config/wdio.shared.config.ts
@@ -1,13 +1,9 @@
-export interface SessionFlagsConfig extends WebdriverIO.Config {
-  firstAppStart: boolean;
-}
-
 /**
  * All not needed configurations, for this boilerplate, are removed.
  * If you want to know which configuration options you have then you can
  * check https://webdriver.io/docs/configurationfile
  */
-export const config: SessionFlagsConfig = {
+export const config: WebdriverIO.Config = {
   autoCompileOpts: {
     autoCompile: true,
     // see https://github.com/TypeStrong/ts-node#cli-and-programmatic-options
@@ -128,17 +124,6 @@ export const config: SessionFlagsConfig = {
      */
     timeout: 1200000,
   },
-
-  // =====
-  // Session flags
-  // =====
-  //
-  /**
-   * Custom property that is used to determine if the app is already launched for the first time
-   * This property is needed because the first time the app is automatically started, so a double
-   * restart is not needed.
-   */
-  firstAppStart: true,
 
   //
   // =====

--- a/tests/config/wdio.web.config.ts
+++ b/tests/config/wdio.web.config.ts
@@ -41,6 +41,14 @@ config.capabilities = [
     maxInstances: 1,
     browserName: 'chrome',
     'goog:chromeOptions': {
+      args: ['--window-size=500,1000'],
+      // See https://chromedriver.chromium.org/mobile-emulation
+      // For more details
+      mobileEmulation: {
+        deviceMetrics: { width: 393, height: 851, pixelRatio: 3 },
+        userAgent:
+          'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36',
+      },
       prefs: {
         'profile.default_content_setting_values.media_stream_camera': 1,
         'profile.default_content_setting_values.media_stream_mic': 1,

--- a/tests/helpers/element.ts
+++ b/tests/helpers/element.ts
@@ -7,7 +7,7 @@ export async function waitForElement(selector: string, { visibilityTimeout = 500
 }
 
 export async function blur(selector: string, { visibilityTimeout = 5000 }: ElementActionOptions = {}) {
-  browser.execute((sel) => {
+  return browser.execute((sel) => {
     const el = document.querySelector(sel);
     if (el) {
       (el as any).blur();
@@ -17,8 +17,9 @@ export async function blur(selector: string, { visibilityTimeout = 5000 }: Eleme
 
 export async function tryAcceptAlert() {
   try {
-    await driver.acceptAlert();
+    return driver.acceptAlert();
   } catch (e) {
     console.warn('No alert to accept');
+    return Promise.resolve();
   }
 }

--- a/tests/helpers/element.ts
+++ b/tests/helpers/element.ts
@@ -20,6 +20,5 @@ export async function tryAcceptAlert() {
     return driver.acceptAlert();
   } catch (e) {
     console.warn('No alert to accept');
-    return Promise.resolve();
   }
 }

--- a/tests/helpers/gestures.ts
+++ b/tests/helpers/gestures.ts
@@ -91,7 +91,7 @@ export class Gestures {
    * Swipe down based on a percentage
    */
   static async swipeDown(percentage = 1) {
-    await this.swipeOnPercentage(
+    return this.swipeOnPercentage(
       this.calculateXY(SWIPE_DIRECTION.down.start, percentage),
       this.calculateXY(SWIPE_DIRECTION.down.end, percentage)
     );
@@ -101,7 +101,7 @@ export class Gestures {
    * Swipe Up based on a percentage
    */
   static async swipeUp(percentage = 1) {
-    await this.swipeOnPercentage(
+    return this.swipeOnPercentage(
       this.calculateXY(SWIPE_DIRECTION.up.start, percentage),
       this.calculateXY(SWIPE_DIRECTION.up.end, percentage)
     );
@@ -111,7 +111,7 @@ export class Gestures {
    * Swipe left based on a percentage
    */
   static async swipeLeft(percentage = 1) {
-    await this.swipeOnPercentage(
+    return this.swipeOnPercentage(
       this.calculateXY(SWIPE_DIRECTION.left.start, percentage),
       this.calculateXY(SWIPE_DIRECTION.left.end, percentage)
     );
@@ -121,7 +121,7 @@ export class Gestures {
    * Swipe right based on a percentage
    */
   static async swipeRight(percentage = 1) {
-    await this.swipeOnPercentage(
+    return this.swipeOnPercentage(
       this.calculateXY(SWIPE_DIRECTION.right.start, percentage),
       this.calculateXY(SWIPE_DIRECTION.right.end, percentage)
     );
@@ -143,7 +143,7 @@ export class Gestures {
       to
     );
 
-    await this.swipe(pressOptions, moveToScreenCoordinates);
+    return this.swipe(pressOptions, moveToScreenCoordinates);
   }
 
   /**
@@ -174,7 +174,7 @@ export class Gestures {
       },
     ]);
     // Add a pause, just to make sure the swipe is done
-    await driver.pause(1000);
+    return driver.pause(1000);
   }
 
   /**

--- a/tests/helpers/ionic/components/button.ts
+++ b/tests/helpers/ionic/components/button.ts
@@ -27,6 +27,6 @@ export class IonicButton extends IonicComponent {
     if (scroll) {
       await button.scrollIntoView();
     }
-    await button.click();
+    return button.click();
   }
 }

--- a/tests/helpers/ionic/components/item.ts
+++ b/tests/helpers/ionic/components/item.ts
@@ -20,6 +20,6 @@ export class IonicItem extends IonicComponent {
     if (scroll) {
       await button.scrollIntoView();
     }
-    await button.click();
+    return button.click();
   }
 }

--- a/tests/helpers/ionic/components/menu.ts
+++ b/tests/helpers/ionic/components/menu.ts
@@ -26,7 +26,9 @@ export class IonicMenu extends IonicComponent {
 
     // Let the menu animate open/closed
     if (delayForAnimation) {
-      await driver.pause(500);
+      return driver.pause(500);
     }
+
+    return Promise.resolve();
   }
 }

--- a/tests/helpers/ionic/components/menu.ts
+++ b/tests/helpers/ionic/components/menu.ts
@@ -28,7 +28,5 @@ export class IonicMenu extends IonicComponent {
     if (delayForAnimation) {
       return driver.pause(500);
     }
-
-    return Promise.resolve();
   }
 }

--- a/tests/helpers/ionic/components/segment.ts
+++ b/tests/helpers/ionic/components/segment.ts
@@ -18,7 +18,7 @@ export class IonicSegment extends IonicComponent {
         return new IonicSegmentButton(button);
       }
     }
-    return null;
+    return Promise.resolve(null);
   }
 }
 
@@ -32,6 +32,6 @@ export class IonicSegmentButton extends IonicComponent {
     if (scroll) {
       await button.scrollIntoView();
     }
-    await button.click();
+    return button.click();
   }
 }

--- a/tests/helpers/ionic/components/select.ts
+++ b/tests/helpers/ionic/components/select.ts
@@ -9,7 +9,7 @@ export class IonicSelect extends IonicComponent {
   async open() {
     await (await this.$).click();
     // Wait for the alert to popup
-    await pause(1000);
+    return pause(1000);
   }
 
   async select(n: number) {
@@ -22,7 +22,7 @@ export class IonicSelect extends IonicComponent {
     const cancel = await waitForElement('.alert-button-role-cancel');
     await cancel.click();
     // Allow alert to close
-    await cancel.waitForDisplayed({ reverse: true });
+    return cancel.waitForDisplayed({ reverse: true });
   }
 
   async ok() {
@@ -31,6 +31,6 @@ export class IonicSelect extends IonicComponent {
     );
     await ok.click();
     // Allow alert to close
-    await ok.waitForDisplayed({ reverse: true });
+    return ok.waitForDisplayed({ reverse: true });
   }
 }

--- a/tests/helpers/ionic/components/slides.ts
+++ b/tests/helpers/ionic/components/slides.ts
@@ -22,7 +22,7 @@ export class IonicSlides extends IonicComponent {
     const y = Math.round(SwiperRectangles.y + SwiperRectangles.height / 2);
 
     // Execute the gesture by providing a starting position and an end position
-    await Gestures.swipe(
+    return Gestures.swipe(
       // Here we start on the right of the Swiper. To make sure that we don't touch the outer most right
       // part of the screen we take 10% of the x-position. The y-position has already been determined.
       {
@@ -46,7 +46,7 @@ export class IonicSlides extends IonicComponent {
     const y = Math.round(SwiperRectangles.y + SwiperRectangles.height / 2);
 
     // Execute the gesture by providing a starting position and an end position
-    await Gestures.swipe(
+    return Gestures.swipe(
       // Here we start on the left of the Swiper. To make sure that we don't touch the outer most left
       // part of the screen we add 10% to the x-position. The y-position has already been determined.
       { x: Math.round(SwiperRectangles.x + SwiperRectangles.width * 0.1), y },
@@ -63,7 +63,7 @@ export class IonicSlides extends IonicComponent {
    * Get the Swiper position and size
    */
   async getSwiperRectangles(): Promise<RectReturn> {
-    const slides2 = await Ionic$.$(this.selector);
+    const slides2 = await Ionic$.$(this.selector as string);
     // Get the rectangles of the Swiper and store it in a global that will be used for a next call.
     // We dont want ask for the rectangles of the Swiper if we already know them.
     // This will save unneeded webdriver calls.

--- a/tests/helpers/ionic/components/textarea.ts
+++ b/tests/helpers/ionic/components/textarea.ts
@@ -9,7 +9,6 @@ export class IonicTextarea extends IonicComponent {
     return browser.execute(
       (selector: string, valueString: string) => {
         const el = document.querySelector(selector);
-        console.log('Found element', el, valueString, selector);
         if (el) {
           (el as any).value = valueString;
         }

--- a/tests/helpers/platform/index.ts
+++ b/tests/helpers/platform/index.ts
@@ -1,4 +1,5 @@
 import { SessionFlagsConfig } from '../../config/wdio.shared.config';
+import { clearIndexedDB } from '../storage';
 import WebView, { CONTEXT_REF } from '../webview';
 
 export * from './android';
@@ -125,10 +126,15 @@ export async function setLocation(lat: number, lng: number) {
 }
 
 export async function restartApp() {
-  if (!(driver.config as SessionFlagsConfig).firstAppStart && !isWeb()) {
-    await driver.reset();
-  }
+  // if ((driver.config as SessionFlagsConfig).firstAppStart && !isWeb()) {
+  //   await driver.reset();
+  // }
 
-  // Set the firstAppstart to false to say that the following test can be reset
-  (driver.config as SessionFlagsConfig).firstAppStart = false;
+  // // Set the firstAppstart to false to say that the following test can be reset
+  // (driver.config as SessionFlagsConfig).firstAppStart = false;
+
+  if (isWeb()) {
+    await url('/tutorial');
+  }
+  await clearIndexedDB('_ionicstorage');
 }

--- a/tests/helpers/platform/index.ts
+++ b/tests/helpers/platform/index.ts
@@ -49,8 +49,6 @@ export function getContext() {
 export async function url(newUrl: string) {
   const currentUrl = await browser.getUrl();
 
-  console.log('Current url', currentUrl);
-
   if (newUrl[0] === '/') {
     // Simulate baseUrl by grabbing the current url and navigating relative
     // to that

--- a/tests/helpers/platform/index.ts
+++ b/tests/helpers/platform/index.ts
@@ -1,4 +1,3 @@
-import { SessionFlagsConfig } from '../../config/wdio.shared.config';
 import { clearIndexedDB } from '../storage';
 import WebView, { CONTEXT_REF } from '../webview';
 
@@ -105,11 +104,11 @@ export function setDevice(device: Device) {
     return Promise.resolve();
   }
 
-  switch (device) {
-    case Device.Mobile: {
-      return driver.setWindowSize(375, 812);
-    }
-  }
+  // switch (device) {
+  //   case Device.Mobile: {
+  //     return driver.setWindowSize(375, 812);
+  //   }
+  // }
 }
 
 export async function setLocation(lat: number, lng: number) {
@@ -125,16 +124,12 @@ export async function setLocation(lat: number, lng: number) {
   });
 }
 
-export async function restartApp() {
-  // if ((driver.config as SessionFlagsConfig).firstAppStart && !isWeb()) {
-  //   await driver.reset();
-  // }
-
-  // // Set the firstAppstart to false to say that the following test can be reset
-  // (driver.config as SessionFlagsConfig).firstAppStart = false;
-
+export async function restartApp(urlPath: string) {
+  // this is needed to set the "default" url on web so the DB can be cleared
   if (isWeb()) {
-    await url('/tutorial');
+    await url(urlPath);
   }
   await clearIndexedDB('_ionicstorage');
+  // Now load the correct url path
+  await url(urlPath);
 }

--- a/tests/helpers/platform/index.ts
+++ b/tests/helpers/platform/index.ts
@@ -1,39 +1,34 @@
-import { clearIndexedDB } from '../storage';
 import WebView, { CONTEXT_REF } from '../webview';
 
 export * from './android';
 export * from './ios';
 
-export enum Device {
-  Mobile = 'mobile',
-}
-
 export async function waitForLoad() {
   if (isWeb()) {
-    return;
+    return Promise.resolve();
   }
-  await WebView.waitForWebsiteLoaded();
+  return WebView.waitForWebsiteLoaded();
 }
 
 export async function switchToNative() {
   if (isWeb()) {
-    return;
+    return Promise.resolve();
   }
 
-  await WebView.switchToContext(CONTEXT_REF.NATIVE);
+  return WebView.switchToContext(CONTEXT_REF.NATIVE);
 }
 
 export async function switchToWeb() {
   if (isWeb()) {
-    return;
+    return Promise.resolve();
   }
 
-  await WebView.switchToContext(CONTEXT_REF.WEBVIEW);
+  return WebView.switchToContext(CONTEXT_REF.WEBVIEW);
 }
 
-export function getContexts() {
+export async function getContexts() {
   if (isWeb()) {
-    return ['WEBVIEW'];
+    return Promise.resolve(['WEBVIEW']);
   }
 
   return driver.getContexts();
@@ -41,7 +36,7 @@ export function getContexts() {
 
 export function getContext() {
   if (isWeb()) {
-    return 'WEBVIEW';
+    return Promise.resolve('WEBVIEW');
   }
 
   return driver.getContext();
@@ -99,22 +94,10 @@ export function isWeb() {
   return !driver.isMobile;
 }
 
-export function setDevice(device: Device) {
-  if (!isWeb()) {
-    return Promise.resolve();
-  }
-
-  // switch (device) {
-  //   case Device.Mobile: {
-  //     return driver.setWindowSize(375, 812);
-  //   }
-  // }
-}
-
 export async function setLocation(lat: number, lng: number) {
   if (isWeb()) {
     // Not available on web
-    return;
+    return Promise.resolve();
   }
 
   return driver.setGeoLocation({
@@ -127,9 +110,8 @@ export async function setLocation(lat: number, lng: number) {
 export async function restartApp(urlPath: string) {
   // this is needed to set the "default" url on web so the DB can be cleared
   if (isWeb()) {
-    await url(urlPath);
+    return url(urlPath);
   }
-  await clearIndexedDB('_ionicstorage');
-  // Now load the correct url path
-  await url(urlPath);
+
+  return Promise.resolve();
 }

--- a/tests/helpers/platform/index.ts
+++ b/tests/helpers/platform/index.ts
@@ -1,3 +1,4 @@
+import { SessionFlagsConfig } from '../../config/wdio.shared.config';
 import WebView, { CONTEXT_REF } from '../webview';
 
 export * from './android';
@@ -121,4 +122,13 @@ export async function setLocation(lat: number, lng: number) {
     longitude: '' + lat,
     altitude: '94.23',
   });
+}
+
+export async function restartApp() {
+  if (!(driver.config as SessionFlagsConfig).firstAppStart && !isWeb()) {
+    await driver.reset();
+  }
+
+  // Set the firstAppstart to false to say that the following test can be reset
+  (driver.config as SessionFlagsConfig).firstAppStart = false;
 }

--- a/tests/helpers/platform/index.ts
+++ b/tests/helpers/platform/index.ts
@@ -112,6 +112,4 @@ export async function restartApp(urlPath: string) {
   if (isWeb()) {
     return url(urlPath);
   }
-
-  return Promise.resolve();
 }

--- a/tests/helpers/storage.ts
+++ b/tests/helpers/storage.ts
@@ -1,5 +1,5 @@
 export async function clearIndexedDB(dbName: string) {
-  return browser.execute((name) => {
+  await browser.execute((name) => {
     indexedDB.deleteDatabase(name);
   }, dbName);
 }

--- a/tests/helpers/storage.ts
+++ b/tests/helpers/storage.ts
@@ -1,5 +1,8 @@
 export async function clearIndexedDB(dbName: string) {
   await browser.execute((name) => {
     indexedDB.deleteDatabase(name);
+    // Needed to reload the page for the DB to be reloaded
+    // for mobile devices
+    document.location.reload();
   }, dbName);
 }

--- a/tests/helpers/storage.ts
+++ b/tests/helpers/storage.ts
@@ -1,8 +1,12 @@
+import { pause } from '.';
+
 export async function clearIndexedDB(dbName: string) {
-  return browser.execute((name) => {
+  await browser.execute((name) => {
     indexedDB.deleteDatabase(name);
     // Needed to reload the page for the DB to be reloaded
     // for mobile devices
     document.location.reload();
   }, dbName);
+
+  return pause(500);
 }

--- a/tests/helpers/storage.ts
+++ b/tests/helpers/storage.ts
@@ -1,5 +1,5 @@
 export async function clearIndexedDB(dbName: string) {
-  await browser.execute((name) => {
+  return browser.execute((name) => {
     indexedDB.deleteDatabase(name);
     // Needed to reload the page for the DB to be reloaded
     // for mobile devices

--- a/tests/pageobjects/login.page.ts
+++ b/tests/pageobjects/login.page.ts
@@ -15,7 +15,7 @@ class Login extends Page {
   async login(username: string, password: string) {
     await this.username.setValue(username);
     await this.password.setValue(password);
-    await this.loginButton.tap();
+    return this.loginButton.tap();
   }
 }
 

--- a/tests/pageobjects/schedule.page.ts
+++ b/tests/pageobjects/schedule.page.ts
@@ -3,7 +3,7 @@ import {
   IonicContent,
   IonicMenu,
   IonicSegment,
-  isWeb,
+  isIOS,
 } from '../helpers';
 import Page from './page';
 
@@ -13,7 +13,7 @@ class Schedule extends Page {
   }
   get filterButton() {
     return new IonicButton(
-      `ion-buttons[slot="end"] > ion-button:nth-child(${isWeb() ? 2 : 1})`
+      `ion-buttons[slot="end"] > ion-button:nth-child(${isIOS() ? 1 : 2})`
     );
   }
   get segment() {

--- a/tests/pageobjects/schedule.page.ts
+++ b/tests/pageobjects/schedule.page.ts
@@ -1,4 +1,10 @@
-import { IonicButton, IonicContent, IonicMenu, IonicSegment } from '../helpers';
+import {
+  IonicButton,
+  IonicContent,
+  IonicMenu,
+  IonicSegment,
+  isWeb,
+} from '../helpers';
 import Page from './page';
 
 class Schedule extends Page {
@@ -6,7 +12,9 @@ class Schedule extends Page {
     return new IonicMenu();
   }
   get filterButton() {
-    return new IonicButton('ion-buttons[slot="end"] > ion-button:nth-child(2)');
+    return new IonicButton(
+      `ion-buttons[slot="end"] > ion-button:nth-child(${isWeb() ? 2 : 1})`
+    );
   }
   get segment() {
     return new IonicSegment('ion-segment');

--- a/tests/pageobjects/signup.page.ts
+++ b/tests/pageobjects/signup.page.ts
@@ -15,7 +15,7 @@ class Signup extends Page {
   async signup(username: string, password: string) {
     await this.username.setValue(username);
     await this.password.setValue(password);
-    await this.signupButton.tap();
+    return this.signupButton.tap();
   }
 }
 

--- a/tests/pageobjects/tutorial.page.ts
+++ b/tests/pageobjects/tutorial.page.ts
@@ -13,19 +13,19 @@ class Tutorial extends Page {
   }
 
   async swipeLeft() {
-    await this.slides.swipeLeft();
+    return this.slides.swipeLeft();
   }
 
   async swipeRight() {
-    await this.slides.swipeRight();
+    return this.slides.swipeRight();
   }
 
   async skip() {
-    await this.skipButton.tap();
+    return this.skipButton.tap();
   }
 
   async continue() {
-    await this.continueButton.tap();
+    return this.continueButton.tap();
   }
 }
 

--- a/tests/specs/app.about.spec.ts
+++ b/tests/specs/app.about.spec.ts
@@ -1,12 +1,11 @@
-import { Device, pause, restartApp, setDevice, url } from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import About from '../pageobjects/about.page';
 
 describe('About', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/app/tabs/about');
     await setDevice(Device.Mobile);
-    await url('/app/tabs/about');
     await pause(500);
   });
 

--- a/tests/specs/app.about.spec.ts
+++ b/tests/specs/app.about.spec.ts
@@ -1,11 +1,12 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import About from '../pageobjects/about.page';
 
 describe('About', () => {
   beforeEach(async () => {
     await restartApp('/app/tabs/about');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/app/tabs/about');
     await pause(500);
   });
 

--- a/tests/specs/app.about.spec.ts
+++ b/tests/specs/app.about.spec.ts
@@ -29,7 +29,6 @@ describe('About', () => {
     await location.ok();
     const austinImage = await About.austinImage;
     await pause(500);
-    console.log(await austinImage.getCSSProperty('opacity'));
     await expect((await austinImage.getCSSProperty('opacity')).value).toEqual(
       1
     );

--- a/tests/specs/app.about.spec.ts
+++ b/tests/specs/app.about.spec.ts
@@ -1,22 +1,11 @@
-import {
-  Device,
-  pause,
-  setDevice,
-  url,
-  waitForLoad,
-  switchToWeb,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice, url } from '../helpers';
 
 import About from '../pageobjects/about.page';
 
 describe('About', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/app/tabs/about');
     await pause(500);
   });

--- a/tests/specs/app.account.spec.ts
+++ b/tests/specs/app.account.spec.ts
@@ -5,8 +5,7 @@ import Login from '../pageobjects/login.page';
 
 describe('Account', () => {
   beforeEach(async () => {
-    await restartApp();
-    await url('/login');
+    await restartApp('/login');
     await pause(500);
     await Login.login('test', 'test');
     await pause(500);

--- a/tests/specs/app.account.spec.ts
+++ b/tests/specs/app.account.spec.ts
@@ -1,4 +1,4 @@
-import { Device, pause, restartApp, setDevice, url } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import Account from '../pageobjects/account.page';
 import Login from '../pageobjects/login.page';
@@ -6,11 +6,12 @@ import Login from '../pageobjects/login.page';
 describe('Account', () => {
   beforeEach(async () => {
     await restartApp('/login');
+    await clearIndexedDB('_ionicstorage');
+    await url('/login');
     await pause(500);
     await Login.login('test', 'test');
     await pause(500);
     await url('/account');
-    await setDevice(Device.Mobile);
   });
 
   it('Should open change username alert', async () => {

--- a/tests/specs/app.account.spec.ts
+++ b/tests/specs/app.account.spec.ts
@@ -1,29 +1,17 @@
-import {
-  Device,
-  pause,
-  setDevice,
-  switchToWeb,
-  url,
-  waitForLoad,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice, url } from '../helpers';
 
 import Account from '../pageobjects/account.page';
 import Login from '../pageobjects/login.page';
 
 describe('Account', () => {
-  before(async () => {
-    await waitForLoad();
-    await switchToWeb();
+  beforeEach(async () => {
+    await restartApp();
     await url('/login');
     await pause(500);
     await Login.login('test', 'test');
     await pause(500);
     await url('/account');
-  });
-
-  beforeEach(async () => {
     await setDevice(Device.Mobile);
-    await switchToWeb();
   });
 
   it('Should open change username alert', async () => {

--- a/tests/specs/app.login.spec.ts
+++ b/tests/specs/app.login.spec.ts
@@ -1,11 +1,12 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import Login from '../pageobjects/login.page';
 
 describe('Login', () => {
   beforeEach(async () => {
     await restartApp('/login');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/login');
     await pause(500);
   });
 

--- a/tests/specs/app.login.spec.ts
+++ b/tests/specs/app.login.spec.ts
@@ -1,18 +1,11 @@
-import {
-  Device,
-  pause,
-  restartApp,
-  setDevice,
-  url,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import Login from '../pageobjects/login.page';
 
 describe('Login', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/login');
     await setDevice(Device.Mobile);
-    await url('/login');
     await pause(500);
   });
 

--- a/tests/specs/app.login.spec.ts
+++ b/tests/specs/app.login.spec.ts
@@ -1,22 +1,17 @@
 import {
   Device,
   pause,
+  restartApp,
   setDevice,
-  switchToWeb,
   url,
-  waitForLoad,
 } from '../helpers';
 
 import Login from '../pageobjects/login.page';
 
 describe('Login', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/login');
     await pause(500);
   });

--- a/tests/specs/app.map.spec.ts
+++ b/tests/specs/app.map.spec.ts
@@ -1,11 +1,12 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import Map from '../pageobjects/map.page';
 
 describe('Map', () => {
   beforeEach(async () => {
     await restartApp('/app/tabs/map');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/app/tabs/map');
     await pause(500);
   });
 

--- a/tests/specs/app.map.spec.ts
+++ b/tests/specs/app.map.spec.ts
@@ -1,22 +1,17 @@
 import {
   Device,
   pause,
+  restartApp,
   setDevice,
-  switchToWeb,
   url,
-  waitForLoad,
 } from '../helpers';
 
 import Map from '../pageobjects/map.page';
 
 describe('Map', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/app/tabs/map');
     await pause(500);
   });

--- a/tests/specs/app.map.spec.ts
+++ b/tests/specs/app.map.spec.ts
@@ -1,18 +1,11 @@
-import {
-  Device,
-  pause,
-  restartApp,
-  setDevice,
-  url,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import Map from '../pageobjects/map.page';
 
 describe('Map', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/app/tabs/map');
     await setDevice(Device.Mobile);
-    await url('/app/tabs/map');
     await pause(500);
   });
 

--- a/tests/specs/app.schedule-filter.spec.ts
+++ b/tests/specs/app.schedule-filter.spec.ts
@@ -1,5 +1,11 @@
-import { SchedulePage } from '../../src/app/pages/schedule/schedule';
-import { Device, Ionic$, pause, setDevice, switchToWeb, url, waitForLoad } from '../helpers';
+import {
+  Device,
+  pause,
+  setDevice,
+  switchToWeb,
+  url,
+  waitForLoad,
+} from '../helpers';
 
 import schedulePage from '../pageobjects/schedule.page';
 

--- a/tests/specs/app.schedule-filter.spec.ts
+++ b/tests/specs/app.schedule-filter.spec.ts
@@ -1,11 +1,12 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import schedulePage from '../pageobjects/schedule.page';
 
 describe('Schedule Filter', () => {
   beforeEach(async () => {
     await restartApp('/app/tabs/schedule');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/app/tabs/schedule');
     await pause(200);
     await schedulePage.filterButton.tap();
     await pause(400);

--- a/tests/specs/app.schedule-filter.spec.ts
+++ b/tests/specs/app.schedule-filter.spec.ts
@@ -1,22 +1,17 @@
 import {
   Device,
   pause,
+  restartApp,
   setDevice,
-  switchToWeb,
   url,
-  waitForLoad,
 } from '../helpers';
 
 import schedulePage from '../pageobjects/schedule.page';
 
 describe('Schedule Filter', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/app/tabs/schedule');
     await pause(200);
     await schedulePage.filterButton.tap();

--- a/tests/specs/app.schedule-filter.spec.ts
+++ b/tests/specs/app.schedule-filter.spec.ts
@@ -1,18 +1,11 @@
-import {
-  Device,
-  pause,
-  restartApp,
-  setDevice,
-  url,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import schedulePage from '../pageobjects/schedule.page';
 
 describe('Schedule Filter', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/app/tabs/schedule');
     await setDevice(Device.Mobile);
-    await url('/app/tabs/schedule');
     await pause(200);
     await schedulePage.filterButton.tap();
     await pause(400);

--- a/tests/specs/app.schedule.spec.ts
+++ b/tests/specs/app.schedule.spec.ts
@@ -1,11 +1,12 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import Schedule from '../pageobjects/schedule.page';
 
 describe('Schedule', () => {
   beforeEach(async () => {
     await restartApp('/app/tabs/schedule');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/app/tabs/schedule');
     await pause(500);
   });
 

--- a/tests/specs/app.schedule.spec.ts
+++ b/tests/specs/app.schedule.spec.ts
@@ -1,11 +1,10 @@
-import { Device, pause, restartApp, setDevice, url } from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import Schedule from '../pageobjects/schedule.page';
 
 describe('Schedule', () => {
   beforeEach(async () => {
-    await restartApp();
-    await url('/app/tabs/schedule');
+    await restartApp('/app/tabs/schedule');
     await setDevice(Device.Mobile);
     await pause(500);
   });

--- a/tests/specs/app.schedule.spec.ts
+++ b/tests/specs/app.schedule.spec.ts
@@ -1,21 +1,10 @@
-import {
-  Device,
-  pause,
-  setDevice,
-  url,
-  waitForLoad,
-  switchToWeb,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice, url } from '../helpers';
 
 import Schedule from '../pageobjects/schedule.page';
 
 describe('Schedule', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
-    await switchToWeb();
+    await restartApp();
     await url('/app/tabs/schedule');
     await setDevice(Device.Mobile);
     await pause(500);

--- a/tests/specs/app.schedule.spec.ts
+++ b/tests/specs/app.schedule.spec.ts
@@ -3,7 +3,6 @@ import {
   pause,
   setDevice,
   url,
-  waitForElement,
   waitForLoad,
   switchToWeb,
 } from '../helpers';

--- a/tests/specs/app.session-detail.spec.ts
+++ b/tests/specs/app.session-detail.spec.ts
@@ -1,4 +1,4 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import Schedule from '../pageobjects/schedule.page';
 import SessionDetail from '../pageobjects/session-detail.page';
@@ -6,7 +6,8 @@ import SessionDetail from '../pageobjects/session-detail.page';
 describe('Session Detail', () => {
   beforeEach(async () => {
     await restartApp('/app/tabs/schedule/session/1');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/app/tabs/schedule/session/1');
     await pause(500);
   });
 

--- a/tests/specs/app.session-detail.spec.ts
+++ b/tests/specs/app.session-detail.spec.ts
@@ -1,12 +1,11 @@
-import { Device, pause, restartApp, setDevice, url } from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import Schedule from '../pageobjects/schedule.page';
 import SessionDetail from '../pageobjects/session-detail.page';
 
 describe('Session Detail', () => {
   beforeEach(async () => {
-    await restartApp();
-    await url('/app/tabs/schedule/session/1');
+    await restartApp('/app/tabs/schedule/session/1');
     await setDevice(Device.Mobile);
     await pause(500);
   });

--- a/tests/specs/app.session-detail.spec.ts
+++ b/tests/specs/app.session-detail.spec.ts
@@ -1,22 +1,11 @@
-import {
-  Device,
-  pause,
-  setDevice,
-  url,
-  waitForLoad,
-  switchToWeb,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice, url } from '../helpers';
 
 import Schedule from '../pageobjects/schedule.page';
 import SessionDetail from '../pageobjects/session-detail.page';
 
 describe('Session Detail', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
-    await switchToWeb();
+    await restartApp();
     await url('/app/tabs/schedule/session/1');
     await setDevice(Device.Mobile);
     await pause(500);

--- a/tests/specs/app.signup.spec.ts
+++ b/tests/specs/app.signup.spec.ts
@@ -2,22 +2,17 @@ import {
   Device,
   getUrl,
   pause,
+  restartApp,
   setDevice,
-  switchToWeb,
   url,
-  waitForLoad,
 } from '../helpers';
 
 import Signup from '../pageobjects/signup.page';
 
 describe('Signup', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/signup');
     await pause(500);
   });

--- a/tests/specs/app.signup.spec.ts
+++ b/tests/specs/app.signup.spec.ts
@@ -1,19 +1,11 @@
-import {
-  Device,
-  getUrl,
-  pause,
-  restartApp,
-  setDevice,
-  url,
-} from '../helpers';
+import { Device, getUrl, pause, restartApp, setDevice } from '../helpers';
 
 import Signup from '../pageobjects/signup.page';
 
 describe('Signup', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/signup');
     await setDevice(Device.Mobile);
-    await url('/signup');
     await pause(500);
   });
 

--- a/tests/specs/app.signup.spec.ts
+++ b/tests/specs/app.signup.spec.ts
@@ -1,11 +1,12 @@
-import { Device, getUrl, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, getUrl, pause, restartApp, url } from '../helpers';
 
 import Signup from '../pageobjects/signup.page';
 
 describe('Signup', () => {
   beforeEach(async () => {
     await restartApp('/signup');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/signup');
     await pause(500);
   });
 

--- a/tests/specs/app.speaker-detail.spec.ts
+++ b/tests/specs/app.speaker-detail.spec.ts
@@ -1,11 +1,12 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import SpeakerDetail from '../pageobjects/speaker-detail.page';
 
 describe('Speaker Detail', () => {
   beforeEach(async () => {
     await restartApp('/app/tabs/speakers/speaker-details/3');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/app/tabs/speakers/speaker-details/3');
     await pause(500);
   });
 

--- a/tests/specs/app.speaker-detail.spec.ts
+++ b/tests/specs/app.speaker-detail.spec.ts
@@ -1,12 +1,11 @@
-import { Device, pause, restartApp, setDevice, url } from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import SpeakerDetail from '../pageobjects/speaker-detail.page';
 
 describe('Speaker Detail', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/app/tabs/speakers/speaker-details/3');
     await setDevice(Device.Mobile);
-    await url('/app/tabs/speakers/speaker-details/3');
     await pause(500);
   });
 

--- a/tests/specs/app.speaker-detail.spec.ts
+++ b/tests/specs/app.speaker-detail.spec.ts
@@ -1,22 +1,11 @@
-import {
-  Device,
-  pause,
-  setDevice,
-  switchToWeb,
-  url,
-  waitForLoad,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice, url } from '../helpers';
 
 import SpeakerDetail from '../pageobjects/speaker-detail.page';
 
 describe('Speaker Detail', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/app/tabs/speakers/speaker-details/3');
     await pause(500);
   });

--- a/tests/specs/app.speaker-list.spec.ts
+++ b/tests/specs/app.speaker-list.spec.ts
@@ -3,16 +3,14 @@ import {
   pause,
   restartApp,
   setDevice,
-  url,
 } from '../helpers';
 
 import SpeakerList from '../pageobjects/speaker-list.page';
 
 describe('Speaker List', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/app/tabs/speakers');
     await setDevice(Device.Mobile);
-    await url('/app/tabs/speakers');
     await pause(500);
   });
 

--- a/tests/specs/app.speaker-list.spec.ts
+++ b/tests/specs/app.speaker-list.spec.ts
@@ -1,8 +1,8 @@
 import {
-  Device,
+  clearIndexedDB,
   pause,
   restartApp,
-  setDevice,
+  url,
 } from '../helpers';
 
 import SpeakerList from '../pageobjects/speaker-list.page';
@@ -10,7 +10,8 @@ import SpeakerList from '../pageobjects/speaker-list.page';
 describe('Speaker List', () => {
   beforeEach(async () => {
     await restartApp('/app/tabs/speakers');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/app/tabs/speakers');
     await pause(500);
   });
 

--- a/tests/specs/app.speaker-list.spec.ts
+++ b/tests/specs/app.speaker-list.spec.ts
@@ -1,22 +1,17 @@
 import {
   Device,
   pause,
+  restartApp,
   setDevice,
-  switchToWeb,
   url,
-  waitForLoad,
 } from '../helpers';
 
 import SpeakerList from '../pageobjects/speaker-list.page';
 
 describe('Speaker List', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/app/tabs/speakers');
     await pause(500);
   });

--- a/tests/specs/app.support.spec.ts
+++ b/tests/specs/app.support.spec.ts
@@ -1,12 +1,11 @@
-import { Device, pause, restartApp, setDevice, url } from '../helpers';
+import { Device, pause, restartApp, setDevice } from '../helpers';
 
 import Support from '../pageobjects/support.page';
 
 describe('Support', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/support');
     await setDevice(Device.Mobile);
-    await url('/support');
     await pause(500);
   });
 

--- a/tests/specs/app.support.spec.ts
+++ b/tests/specs/app.support.spec.ts
@@ -1,11 +1,12 @@
-import { Device, pause, restartApp, setDevice } from '../helpers';
+import { clearIndexedDB, pause, restartApp, url } from '../helpers';
 
 import Support from '../pageobjects/support.page';
 
 describe('Support', () => {
   beforeEach(async () => {
     await restartApp('/support');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/support');
     await pause(500);
   });
 

--- a/tests/specs/app.support.spec.ts
+++ b/tests/specs/app.support.spec.ts
@@ -1,22 +1,11 @@
-import {
-  Device,
-  pause,
-  setDevice,
-  switchToWeb,
-  url,
-  waitForLoad,
-} from '../helpers';
+import { Device, pause, restartApp, setDevice, url } from '../helpers';
 
 import Support from '../pageobjects/support.page';
 
 describe('Support', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
+    await restartApp();
     await setDevice(Device.Mobile);
-    await switchToWeb();
     await url('/support');
     await pause(500);
   });

--- a/tests/specs/app.tutorial.spec.ts
+++ b/tests/specs/app.tutorial.spec.ts
@@ -2,7 +2,6 @@ import {
   clearIndexedDB,
   pause,
   getUrl,
-  url,
   setDevice,
   Device,
   restartApp,
@@ -12,9 +11,8 @@ import Tutorial from '../pageobjects/tutorial.page';
 
 describe('Tutorial', () => {
   beforeEach(async () => {
-    await restartApp();
+    await restartApp('/tutorial');
     await setDevice(Device.Mobile);
-    await url('/tutorial');
   });
 
   it('Should load swiper', async () => {

--- a/tests/specs/app.tutorial.spec.ts
+++ b/tests/specs/app.tutorial.spec.ts
@@ -13,9 +13,8 @@ import Tutorial from '../pageobjects/tutorial.page';
 describe('Tutorial', () => {
   beforeEach(async () => {
     await restartApp();
-    await url('/tutorial');
     await setDevice(Device.Mobile);
-    await clearIndexedDB('_ionicstorage');
+    await url('/tutorial');
   });
 
   it('Should load swiper', async () => {

--- a/tests/specs/app.tutorial.spec.ts
+++ b/tests/specs/app.tutorial.spec.ts
@@ -4,20 +4,15 @@ import {
   getUrl,
   url,
   setDevice,
-  switchToWeb,
   Device,
-  waitForLoad,
+  restartApp,
 } from '../helpers';
 
 import Tutorial from '../pageobjects/tutorial.page';
 
 describe('Tutorial', () => {
-  before(async () => {
-    await waitForLoad();
-  });
-
   beforeEach(async () => {
-    await switchToWeb();
+    await restartApp();
     await url('/tutorial');
     await setDevice(Device.Mobile);
     await clearIndexedDB('_ionicstorage');

--- a/tests/specs/app.tutorial.spec.ts
+++ b/tests/specs/app.tutorial.spec.ts
@@ -2,9 +2,8 @@ import {
   clearIndexedDB,
   pause,
   getUrl,
-  setDevice,
-  Device,
   restartApp,
+  url,
 } from '../helpers';
 
 import Tutorial from '../pageobjects/tutorial.page';
@@ -12,7 +11,8 @@ import Tutorial from '../pageobjects/tutorial.page';
 describe('Tutorial', () => {
   beforeEach(async () => {
     await restartApp('/tutorial');
-    await setDevice(Device.Mobile);
+    await clearIndexedDB('_ionicstorage');
+    await url('/tutorial');
   });
 
   it('Should load swiper', async () => {

--- a/tests/specs/app.tutorial.spec.ts
+++ b/tests/specs/app.tutorial.spec.ts
@@ -1,10 +1,4 @@
-import {
-  clearIndexedDB,
-  pause,
-  getUrl,
-  restartApp,
-  url,
-} from '../helpers';
+import { clearIndexedDB, pause, getUrl, restartApp, url } from '../helpers';
 
 import Tutorial from '../pageobjects/tutorial.page';
 


### PR DESCRIPTION
This PR contains:
- remove console.logs
- fix schedule test on mobile
- optimise execution by:
  - automatically switching to a webview
  - not restarting the app between sessions
  - cleaning the state between sessions


# Execution times
**Android:**
- **before changes:** average of 4:00 min
- **after changes:** average of around 2:45 min

**iOS:**
- **before changes:** average of 3:10 min
- **after changes:** average of around 2:40 min

# Extra
The Chrome mobile caps are adjusted to a more reasonable mobile size

![image](https://user-images.githubusercontent.com/11979740/151406594-c1939eb9-402a-4492-a7fd-0e868819f132.png)
